### PR TITLE
Refine responsive layout for Lumigency simulator

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,8 +10,10 @@
 <body>
   <div class="split-layout">
     <div class="left-column">
-      <img src="https://simulator-lac.vercel.app/LOGO2025.png" alt="Logo Lumigency">
-   <h1>🤝Simulez votre potentiel en affiliation</h1>
+      <div class="logo-wrap">
+        <img src="https://simulator-lac.vercel.app/LOGO2025.png" alt="Logo Lumigency">
+      </div>
+      <h1>🤝Simulez votre potentiel en affiliation</h1>
 
 <ul class="benefits-list">
   <li>✔ <span>Estimez vos ventes potentielles.</span></li>

--- a/style.css
+++ b/style.css
@@ -1,415 +1,192 @@
-body {
-  font-family: 'Poppins', sans-serif;
-  background: #F7F5F3;
-  color: #222;
-  margin: 0;
-  padding: 0;
-}
-
-/* === Colonne gauche === */
-.left-column {
-  background: linear-gradient(to right, #2020ff, #809fff);
-  color: white;
-  width: 35%;
-  padding: 60px 40px 40px; /* un peu plus d’air en haut */
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: flex-start; /* pour un bon flux vertical */
-  text-align: center;
-  min-height: 100vh;
-  position: relative;
+* {
   box-sizing: border-box;
 }
 
-/* Logo */
-.left-column img {
-  max-width: 160px;
-  margin-bottom: 25px;
+html,
+body {
+  height: 100%;
 }
 
-/* Titre principal */
+body {
+  margin: 0;
+  font-family: 'Poppins', sans-serif;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  background: #F7F5F3;
+  color: #222;
+  overflow-x: hidden;
+}
+
+a {
+  color: inherit;
+}
+
+button {
+  font-family: 'Poppins', sans-serif;
+}
+
+.split-layout {
+  display: flex;
+  justify-content: space-between;
+  align-items: stretch;
+  min-height: 100vh;
+  gap: 0;
+  transition: opacity 0.3s ease;
+}
+
+.split-layout.show-results {
+  justify-content: center;
+  align-items: center;
+}
+
+.left-column {
+  width: 35%;
+  background: linear-gradient(to bottom, #2020ff, #809fff);
+  color: #ffffff;
+  padding: 60px 40px 40px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  position: relative;
+  gap: 24px;
+}
+
+.left-column .logo-wrap {
+  width: 100%;
+  max-width: 140px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.left-column .logo-wrap img {
+  max-width: 100%;
+  height: auto;
+}
+
 .left-column h1 {
   font-size: 1.7rem;
-  margin-bottom: 30px;
-  line-height: 1.3;
+  margin: 0;
+  color: #ffffff;
 }
 
-/* Bénefits */
-.benefits-list li::first-letter {
-  line-height: 1;
-}
-.benefits-list li {
-
-  font-size: 0.95rem;
-  margin: 10px 0;
-  line-height: 1.6;
-  color: #f7f7f7;
+.benefits-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  width: 100%;
+  max-width: 360px;
   display: flex;
-  align-items: center;          /* ✅ centre parfaitement verticalement emoji + texte */
-  justify-content: center;      /* ✅ centre horizontalement dans la colonne */
-  gap: 10px;                    /* espace fixe entre emoji et texte */
-  text-align: center;
-  white-space: nowrap;          /* ✅ empêche le retour à la ligne */
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 12px;
 }
 
-.benefits-list li span {
-  display: inline-block;
-  line-height: 1;               /* ✅ garde le texte centré verticalement */
-  vertical-align: middle;
+.benefits-list li {
+  display: flex;
+  align-items: center;
+  gap: 10px;
   font-size: 0.95rem;
+  color: #f7f7f7;
+  text-align: left;
 }
 
-/* Pour mobile */
-@media (max-width: 420px) {
-  .benefits-list li {
-    white-space: normal;
-  }
-}
-
-
-/* ✅ Supprime les icônes "✅" ou puces */
-.left-column ul li::before {
-  content: none;
-}
-
-/* === Bloc "Le saviez-vous ?" === */
 .insight-card {
-  background: #ffffff; /* ✅ fond blanc */
+  width: 100%;
+  max-width: 360px;
+  background: #ffffff;
   color: #1a1a1a;
   border-radius: 14px;
-  box-shadow: 0 6px 16px rgba(0,0,0,0.12);
-  padding: 18px 22px;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.12);
+  padding: 24px;
   text-align: left;
-  margin-top: 10px;
-  width: 100%;
-  max-width: 320px;
-  font-size: 0.9rem;
 }
 
 .insight-card strong {
   color: #0000FF;
 }
 
-
-/* === Signature Lumigency === */
-.signature {
+.lumigency-signature {
+  margin-top: auto;
   font-size: 0.85rem;
-  opacity: 0.9;
   text-align: center;
-  margin-top: auto; /* ✅ reste en bas */
-  padding-top: 20px;
+  color: #ffffff;
+  opacity: 0.9;
+  padding-top: 10px;
 }
 
-.signature strong {
-  color: #fff;
+.lumigency-signature strong {
   font-weight: 600;
 }
 
 .right-column {
   width: 60%;
+  max-width: 700px;
   padding: 50px;
-  background: #fff;
+  background: #ffffff;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
 
-.right-column h2 {
+.right-column .subtitle {
   font-size: 1.4rem;
-  margin-bottom: 25px;
+  margin: 0 0 25px;
   color: #0000FF;
 }
 
-.right-column h2 mark {
+.right-column .subtitle mark {
   background: #ffe6f0;
-  padding: 0 4px;
-  border-radius: 4px;
   color: #0000FF;
-}
-
-.insight-box {
-  background: #fff;
-  border-radius: 16px;
-  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.08);
-  padding: 24px;
-  margin-bottom: 30px;
-  font-size: 0.95rem;
-  line-height: 1.6;
-  color: #333;
-}
-
-.insight-box strong {
-  font-weight: 600;
+  border-radius: 4px;
+  padding: 0 4px;
 }
 
 form {
-  background: #fff;
+  background: #ffffff;
   padding: 30px;
   border-radius: 14px;
   box-shadow: 0 6px 16px rgba(0, 0, 0, 0.06);
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
 }
 
 label {
   font-weight: 600;
-  display: block;
-  margin: 20px 0 8px;
-  line-height: 1.4;
-}
-
-form > label:not(:first-of-type) {
-  margin-top: 20px;
-}
-
-input:not([type="checkbox"]),
-select {
-  width: 100%;
-  padding: 10px;
-  border: 1px solid #ccc;
-  border-radius: 8px;
   font-size: 0.95rem;
-  background: #fdfdfd;
-}
-
-.range-container {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-top: 5px;
-}
-
-.range-container input[type=range] {
-  flex: 1;
-  margin: 0 10px;
-  accent-color: #0000FF;
-}
-
-.range-value {
-  font-weight: 600;
-  color: #0000FF;
-  margin-top: 5px;
-  text-align: right;
-}
-
-/* === Espacement optimisé pour les leviers === */
-.single-checkbox {
-  margin-top: 10px; /* éloigne légèrement du titre */
+  display: block;
   margin-bottom: 10px;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-weight: 500;
-  font-size: 0.95rem;
-  line-height: 1.4;
 }
 
-.checkbox-group {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 10px 40px; /* 10px vertical / 40px horizontal pour rapprocher les colonnes */
-  margin-top: 5px; /* un peu plus serré sous le checkbox “tous les leviers” */
-}
-
-.checkbox-group label {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 0.92rem;
-  font-weight: 500;
-  color: #222;
-  line-height: 1.3;
-  margin: 0;
-}
-
-.radio-group {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 20px;
-  margin-top: 10px;
-}
-
-.cta {
-  display: block;
-  width: 100%;
-  padding: 16px;
-  margin-top: 30px;
-  background: #849BFF;
-  color: white;
-  text-align: center;
-  font-size: 1.2rem;
-  font-weight: 600;
-  border: none;
-  border-radius: 10px;
-  cursor: pointer;
-  transition: background 0.3s, transform 0.2s;
-}
-
-.cta:hover {
-  background: #0000FF;
-  transform: translateY(-1px);
-}
-
-#chart-levers {
-  max-width: 300px;
-  max-height: 300px;
-  width: 100%;
-  height: auto;
-  display: block;
-  margin: 20px auto;
-}
-
-.results-section {
-  background: #fff;
-  padding: 40px;
-  border-radius: 16px;
-  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.06);
-  margin: 0 auto;
-  max-width: 900px;
+input,
+select,
+textarea {
   font-family: 'Poppins', sans-serif;
-}
-
-.results-section h2 {
-  font-size: 1.6rem;
-  margin-bottom: 10px;
-  color: #0000FF;
-}
-
-.results-section .subtitle {
   font-size: 1rem;
-  color: #555;
-  margin-bottom: 30px;
-}
-
-.kpi-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 20px;
-  margin-bottom: 40px;
-}
-
-.kpi-card {
-  background: #f5f7ff;
-  padding: 20px;
-  border-radius: 12px;
-  box-shadow: 0 4px 12px rgba(0,0,0,0.05);
-  text-align: center;
-}
-
-.kpi-card span {
-  display: block;
-  margin-top: 10px;
-  font-size: 1.2rem;
-  font-weight: 600;
-  color: #0000FF;
-}
-
-.chart-container {
-  max-width: 500px;
-  margin: 0 auto 40px;
-}
-
-.analysis-block {
-  font-size: 0.95rem;
-  background: #F0F4FF;
-  padding: 20px;
-  border-radius: 12px;
-  color: #222;
-  margin-bottom: 30px;
-}
-
-.analysis-block h3 {
-  margin-bottom: 12px;
-  font-size: 1.2rem;
-  color: #0000FF;
-}
-
-.cta-final {
-  text-align: center;
-}
-
-.cta-final a {
-  background: #849BFF;
-  color: white;
-  padding: 14px 28px;
+  padding: 12px;
   border-radius: 10px;
-  font-weight: 600;
-  text-decoration: none;
-  font-size: 1rem;
+  border: 1px solid #d9d9d9;
+  background: #fdfdfd;
+  width: 100%;
 }
 
-.cta-final a:hover {
-  background: #0000FF;
-}
-
-/* Correction alignement case "Je n’ai pas de budget" */
-.single-checkbox input[type=checkbox] {
-  margin-top: 0;
-  margin-bottom: 0;
-  vertical-align: middle;
-}
-.single-checkbox label {
-  margin: 0;
-}
-
-/* === Suggestions d’éditeurs (version finale clean & alignée) === */
-.editor-grid {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center; /* centre même si nombre impair */
-  gap: 20px;
-  margin-top: 20px;
-}
-
-.editor-card {
-  background: #fff;
-  border: 1px solid #e5e7eb;
-  border-radius: 12px;
-  padding: 16px 12px;
-  width: 150px;
-  height: 130px; /* hauteur fixe pour tout aligner */
-  text-align: center;
-  box-shadow: 0 2px 6px rgba(0,0,0,0.06);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.editor-card:hover {
-  transform: translateY(-4px);
-  box-shadow: 0 6px 14px rgba(0,0,0,0.12);
-}
-
-.editor-card img {
-  max-width: 90px;
-  max-height: 50px;
-  object-fit: contain;
-  margin-bottom: 8px;
-}
-
-.editor-card span {
-  font-size: 0.9rem;
-  font-weight: 500;
-  color: #0000FF; /* bleu Lumigency */
-  min-height: 20px; /* stabilise l’espace du texte */
-}
-
-/* === Curseur + input trafic mensuel === */
 .traffic-slider-container {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: 20px;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  margin-bottom: 15px;
 }
 
 .slider-wrapper {
   flex: 1;
-  max-width: 75%;
-  position: relative;
-  margin-top: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
-.traffic-slider-container input[type="range"] {
+.slider-wrapper input[type="range"] {
   width: 100%;
   accent-color: #0000FF;
 }
@@ -418,406 +195,302 @@ select {
   display: flex;
   justify-content: space-between;
   font-size: 0.8rem;
-  color: #666;
-  margin-top: 6px;
-  padding: 0 2%;
+  color: #666666;
 }
 
 .traffic-slider-container input[type="number"] {
-  width: 110px;
-  padding: 8px;
-  border: 1px solid #ccc;
-  border-radius: 8px;
+  max-width: 120px;
   text-align: right;
   font-weight: 600;
-  flex-shrink: 0;
-  align-self: center;
-  margin-top: -6px; /* aligne la case au curseur */
 }
 
-/* === CTA secondaire (lien discret sous le bouton principal) === */
+.form-row {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 20px 24px;
+}
+
+.form-row > div {
+  display: flex;
+  flex-direction: column;
+}
+
+.single-checkbox,
+.checkbox-budget,
+.radio-group label,
+.checkbox-group label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 500;
+  color: #222222;
+}
+
+.single-checkbox,
+.checkbox-budget,
+.radio-group label,
+.checkbox-group label {
+  margin-bottom: 0;
+}
+
+.checkbox-group {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px 24px;
+}
+
+.radio-group {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+}
+
+.alert-hybride {
+  display: none;
+  background: #fff4e5;
+  color: #663c00;
+  border: 1px solid #ffcc80;
+  border-radius: 12px;
+  padding: 16px 20px;
+  font-size: 0.95rem;
+}
+
+.alert-hybride strong {
+  color: #000000;
+}
+
+.cta {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  padding: 16px;
+  margin-top: 10px;
+  background: #849BFF;
+  color: #ffffff;
+  font-size: 1.1rem;
+  font-weight: 600;
+  border: none;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: background 0.3s ease, transform 0.2s ease;
+}
+
+.cta:hover {
+  background: #0000FF;
+  transform: translateY(-1px);
+}
+
 .cta-secondary {
   display: inline-block;
-  margin-top: 14px;
-  color: #0000FF; /* Bleu Lumigency */
-  font-weight: 500;
-  font-size: 0.95rem;
-  text-decoration: none;
-  opacity: 0.8;
-  transition: all 0.25s ease;
+  margin-top: 12px;
   text-align: center;
-  width: 100%;
+  color: #0000FF;
+  font-weight: 500;
+  text-decoration: none;
 }
 
-.cta-secondary:hover {
-  opacity: 1;
-  color: #0732ef;
-  text-decoration: underline;
-  text-underline-offset: 3px;
-}
-
-
-/* Responsive tablette */
-@media (max-width: 900px) {
-  .traffic-slider-container {
-    flex-direction: column;
-    align-items: stretch;
-  }
-
-  .slider-wrapper {
-    max-width: 100%;
-  }
-
-  .slider-labels {
-    font-size: 0.7rem;
-    padding: 0;
-    margin-top: 4px;
-  }
-
-  .traffic-slider-container input[type="number"] {
-    width: 100%;
-    text-align: left;
-    margin-top: 4px;
-  }
-
-  .editor-grid {
-    grid-template-columns: repeat(3, 1fr);
-  }
-}
-
-/* === Amélioration UX globale du simulateur === */
-
-/* Structure principale */
-.split-layout {
-  display: flex;
-  flex-wrap: nowrap;
-  align-items: flex-start;
-  justify-content: stretch;
-  min-height: 100vh;
-  transition: all 0.3s ease;
-}
-
-/* Quand les résultats sont visibles */
 .split-layout.show-results .right-column {
   display: none;
 }
 
+#results {
+  display: none;
+}
+
 .split-layout.show-results #results {
-  display: block;
-  width: 60%;
-  padding: 50px;
-  background: #fff;
-  animation: fadeIn 0.4s ease;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex: 1;
 }
-
-/* Animation douce à l’affichage */
-@keyframes fadeIn {
-  from { opacity: 0; transform: translateY(10px); }
-  to { opacity: 1; transform: translateY(0); }
-}
-
-/* === Ajustement alignement des résultats === */
 
 .results-section {
+  width: 100%;
+  max-width: 900px;
+  margin: 0 auto;
+  background: #ffffff;
+  padding: 40px;
+  border-radius: 16px;
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.06);
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
-  gap: 40px;
+  gap: 32px;
+  animation: fadeIn 0.4s ease;
+}
+
+.results-section h2 {
+  font-size: 1.6rem;
+  margin: 0;
+  color: #0000FF;
+  text-align: center;
+}
+
+.results-section .subtitle {
+  font-size: 1rem;
+  color: #555555;
+  text-align: center;
+  margin: 0;
+  max-width: 720px;
 }
 
 .kpi-grid {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  align-items: stretch;
-  gap: 25px;
   width: 100%;
-  max-width: 1000px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
 }
 
 .kpi-card {
-  flex: 1 1 250px;
-  max-width: 250px;
+  background: #f5f7ff;
+  border-radius: 12px;
+  padding: 20px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
   text-align: center;
+}
+
+.kpi-card strong {
+  display: block;
+  margin-bottom: 12px;
+}
+
+.kpi-card span {
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: #0000FF;
 }
 
 .chart-container {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
-  margin: 0 auto 40px auto;
+  gap: 16px;
+  max-width: 320px;
+  width: 100%;
+  margin: 0 auto;
+  text-align: center;
 }
 
 #chart-levers {
-  display: block;
-  margin: 0 auto;
-  max-width: 320px;
-}
-
-/* === Correction : l'analyse passe sous le camembert === */
-.chart-container,
-.analysis-block {
-  display: block;
   width: 100%;
-  max-width: 900px;
-  margin: 0 auto 30px auto;
+  height: auto;
 }
 
 .analysis-block {
-  text-align: left;
+  width: 100%;
+  background: #F0F4FF;
+  color: #222222;
+  border-radius: 12px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
-.analysis-block {
-  max-width: 900px;
-  margin: 0 auto;
-  text-align: left;
+.analysis-block h3 {
+  margin: 0;
+  color: #0000FF;
+  font-size: 1.1rem;
+}
+
+.analysis-block ul {
+  margin: 0;
+  padding-left: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .editor-grid {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  align-items: flex-start;
-  gap: 25px;
-  max-width: 900px;
-  margin: 20px auto;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(140px, 1fr));
+  gap: 20px;
+  width: 100%;
+  justify-items: stretch;
 }
 
 .editor-card {
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 16px 12px;
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
-  width: 140px;
+  justify-content: space-between;
+  gap: 12px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.06);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  width: 100%;
+}
+
+.editor-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.12);
 }
 
 .editor-card img {
-  width: 100px;
-  height: auto;
-  margin-bottom: 8px;
+  max-width: 90px;
+  max-height: 50px;
+  object-fit: contain;
 }
 
 .editor-card span {
-  font-weight: 600;
-  color: #0000ff;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: #0000FF;
+  text-align: center;
 }
 
-/* Animation douce (optionnelle) */
-.results-section {
-  opacity: 0;
-  transform: translateY(20px);
-  transition: all 0.6s ease;
+.editor-optin {
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
-.split-layout.show-results .results-section {
-  opacity: 1;
-  transform: translateY(0);
-}
-
-/* === Ajustement proximité phrase budget === */
-.checkbox-budget {
-  margin-top: 2px; /* rapproche le texte du champ budget */
+.editor-optin label {
   display: flex;
   align-items: center;
-  gap: 6px;
-  font-size: 0.9rem;
-  line-height: 1.2;
-}
-
-.checkbox-budget input[type="checkbox"] {
-  transform: scale(1.1);
-  accent-color: #0000FF;
-}
-
-/* === Alignement parfait des 4 champs principaux (UX améliorée) === */
-.form-row {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 28px 50px;
-  margin-top: 25px;
-}
-
-.form-row > div {
-  display: flex;
-  flex-direction: column;
+  flex-direction: row;
   gap: 8px;
-  max-width: 100%;
+  font-weight: 500;
+  margin-bottom: 0;
 }
 
-.form-row input[type="number"] {
+#cta-link {
   width: 100%;
-  padding: 10px 14px;
-  border: 1px solid #ccc;
-  border-radius: 8px;
-  font-size: 0.95rem;
-  background: #fdfdfd;
-  transition: all 0.2s ease;
 }
 
-.form-row input[type="number"]:focus {
-  border-color: #0000FF;
-  box-shadow: 0 0 4px rgba(0, 0, 255, 0.2);
+#cta-link .cta {
+  margin-top: 20px;
 }
 
-/* Correction micro-alignement case budget */
-.checkbox-budget {
-  display: flex;
-  align-items: center; /* centre parfaitement verticalement */
-  gap: 8px;
-  margin-top: 4px;
-}
-
-.checkbox-budget input[type="checkbox"] {
-  transform: scale(1.1);
-  accent-color: #0000FF;
-  margin-top: 0; /* retire le décalage */
-}
-
-.checkbox-budget label {
-  margin: 0;
-  line-height: 1.2;
-  font-size: 0.9rem;
-}
-
-/* === Correction alignement radio Oui / Non === */
-.radio-group {
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  gap: 40px; /* espace horizontal équilibré entre Oui et Non */
-  margin-top: 6px;
-}
-
-.radio-group label {
-  display: flex;
-  align-items: center;
-  gap: 6px;
+#restart-btn {
+  margin-top: 16px;
+  background: none;
+  border: none;
+  color: #0000FF;
   font-size: 0.95rem;
   font-weight: 500;
-  color: #222;
-  line-height: 1.2;
-  margin: 0;
-}
-
-/* Responsive ajusté */
-@media (max-width: 768px) {
-  .form-row {
-    grid-template-columns: 1fr;
-  }
-}
-
-/* Alignement des éléments dans la colonne gauche */
-.left-column .content-block {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  gap: 25px;
-}
-
-.divider {
-  width: 70%;
-  height: 1px;
-  background: rgba(255,255,255,0.4);
-  margin: 10px auto 30px; /* descend la ligne plus bas */
-}
-
-/* Signature toujours collée en bas */
-.signature {
-  position: absolute;
-  bottom: 20px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 90%;
-  font-size: 0.85rem;
-  opacity: 0.9;
-  text-align: center;
-}
-
-/* Étend le fond bleu sur toute la hauteur, même si le formulaire est plus long */
-.split-layout {
-  align-items: stretch;
-}
-
-html, body {
-  height: 100%;
-}
-
-/* === Ajustement final : alignement, bloc blanc, ligne signature === */
-.benefits-list {
-  list-style: none;
+  cursor: pointer;
   padding: 0;
-  margin: 0 auto 40px auto;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  width: 100%;
-  max-width: 380px;
 }
 
-.benefits-list li {
-  display: grid;
-  grid-template-columns: 28px auto;
-  align-items: center;
-  justify-content: center;
-  gap: 10px;
-  font-size: 0.95rem;
-  line-height: 1.6;
-  color: #f7f7f7;
-  margin: 8px 0;
-  text-align: left;
+#restart-btn:hover {
+  text-decoration: underline;
 }
 
-.benefits-list li span {
-  display: block;
-}
-
-.insight-card {
-  background: #ffffff;
-  color: #1a1a1a;
-  border-radius: 14px;
-  box-shadow: 0 6px 16px rgba(0,0,0,0.12);
-  padding: 28px 30px;
-  text-align: left;
-  margin-top: 20px;
-  width: 100%;
-  max-width: 400px;
-  font-size: 0.95rem;
-  line-height: 1.6;
-}
-
-.divider {
-  width: 70%;
-  height: 1px;
-  background: rgba(255,255,255,0.4);
-  margin: 80px auto 15px;
-}
-
-.signature {
-  position: relative;
-  bottom: 0;
-  text-align: center;
-  font-size: 0.85rem;
-  color: #fff;
-  opacity: 0.9;
-  margin-bottom: 10px;
-}
-/* === Témoignages en bas de page === */
 .testimonials-section {
-  background: #fff;
+  background: #ffffff;
   padding: 40px 0 60px;
   text-align: center;
-  margin-top: 0; /* ✅ supprime la bande vide au-dessus */
 }
 
 .testimonials-section h2 {
-  color: #0000FF; /* Bleu Lumigency */
+  color: #0000FF;
   font-size: 1.6rem;
-  font-weight: 600;
-  margin-top: 5px;
-  margin-bottom: 25px;
+  margin: 0 0 30px;
 }
 
 .slider-container {
@@ -834,937 +507,167 @@ html, body {
 
 .review {
   flex: 0 0 33.33%;
-  background: #f8f9ff;
+  background: #f5f7ff;
   border: 1px solid #e0e3ff;
   border-radius: 12px;
-  padding: 20px 18px;
+  padding: 24px;
   margin: 0 10px;
-  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.08);
-  box-sizing: border-box;
-  color: #222;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
   text-align: left;
-}
-
-.stars {
-  color: #00c853;
-  margin-bottom: 8px;
-  font-size: 1rem;
-  letter-spacing: 2px;
 }
 
 .review strong {
   display: block;
+  margin-bottom: 8px;
   color: #0000FF;
-  margin-bottom: 6px;
-  font-size: 0.95rem;
 }
 
 .review p {
-  font-size: 0.9rem;
-  line-height: 1.4;
-  color: #333;
-  margin-bottom: 8px;
+  margin: 0 0 10px;
+  font-size: 0.95rem;
 }
 
 .review span {
   font-size: 0.8rem;
-  color: #777;
+  color: #777777;
 }
 
-/* === Responsive pour le slider de témoignages === */
-@media (max-width: 900px) {
-  .review {
-    flex: 0 0 50%; /* 2 témoignages visibles à la fois sur tablette */
-  }
-}
-
-@media (max-width: 600px) {
-  .review {
-    flex: 0 0 100%; /* 1 témoignage à la fois sur mobile */
-  }
-}
-
-/* ✅ Liste des arguments — alignement parfait emoji + texte */
-.benefits-list {
-  list-style: none;
-  padding: 0;
-  margin: 0 auto 25px auto;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start; /* aligne tout à gauche, plus naturel */
-  gap: 16px;
-  width: 100%;
-  max-width: 360px;
-}
-
-.benefits-list li {
-  display: flex;
-  align-items: center;        /* ✅ centre emoji + texte verticalement */
-  justify-content: flex-start;
-  gap: 10px;
-  font-size: 0.95rem;
-  color: #fff;
-  line-height: 1.6;
-  text-align: left;
-}
-
-.benefits-list li::before {
-  content: attr(data-emoji);
-  font-size: 1.2rem;          /* ✅ taille uniforme */
-  line-height: 1;             /* ✅ corrige le décalage vertical */
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 22px;            /* ✅ espace constant */
-}
-
-.benefits-list li span {
-  display: inline-block;
-  vertical-align: middle;
-  line-height: 1.4;
-}
-
-
-/* ✅ Signature Lumigency sur une ligne */
-.lumigency-signature {
-  position: absolute;
-  bottom: 20px;
-  left: 50%;
-  transform: translateX(-50%);
-  font-size: 0.8rem;
-  color: rgba(255, 255, 255, 0.9);
-  text-align: center;
-  line-height: 1.4;
-  white-space: nowrap; /* ✅ empêche le retour à la ligne */
-}
-
-.lumigency-signature strong {
-  color: #fff;
-}
-#restart-btn {
-  display: inline-block;
-  margin-top: 35px; /* plus d’espace au-dessus */
-  background: none;
-  color: #0000FF;
-  border: none;
-  font-size: 0.95rem;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.25s ease;
-  text-align: left;
-  padding: 0;
-}
-
-#restart-btn:hover {
-  color: #0732ef;
-  text-decoration: underline;
-  text-underline-offset: 3px;
-  transform: translateX(2px);
-}
-
-/* === Alerte hybrides === */
-.alert-hybride {
-  display: none;
-  background: #fff4e5; /* fond beige doux */
-  color: #663c00; /* texte brun chaud */
-  border: 1px solid #ffcc80;
-  border-radius: 10px;
-  padding: 14px 18px;
-  margin-top: 20px;
-  margin-bottom: 25px;
-  font-size: 0.95rem;
-  line-height: 1.5;
-  animation: fadeIn 0.4s ease;
-  box-shadow: 0 2px 8px rgba(255, 165, 0, 0.1);
-}
-
-.alert-hybride strong {
-  color: #000;
-}
-
-/* Animation d’apparition douce */
 @keyframes fadeIn {
-  from { opacity: 0; transform: translateY(-5px); }
-  to { opacity: 1; transform: translateY(0); }
-}
-
-/* (optionnel) Effet léger de pulsation quand elle s'affiche */
-@keyframes softPulse {
-  0% { transform: scale(1); opacity: 1; }
-  50% { transform: scale(1.02); opacity: 0.95; }
-  100% { transform: scale(1); opacity: 1; }
-} /* ✅ on ferme enfin la keyframe ! */
-
-/* === Bloc opt-in éditeurs + CTA === */
-.editor-optin {
-  margin-top: 35px;
-  padding-bottom: 40px; /* ✅ espace avant le CTA */
-  text-align: center;
-  font-size: 15px;
-  color: #222;
-  font-weight: 500;
-}
-
-.editor-optin input[type="checkbox"] {
-  transform: scale(1.2);
-  margin-right: 8px;
-  accent-color: #0732ef;
-  vertical-align: middle;
-}
-
-/* === CTA principal === */
-#cta-link {
-  margin-top: 0;
-  padding-top: 25px; /* ✅ ajoute de l’air au-dessus du bouton */
-  display: flex;
-  justify-content: center;
-}
-
-/* === Correctifs généraux pré-mobile === */
-html, body {
-  overflow-x: hidden; /* ✅ évite le scroll horizontal */
-}
-
-input, select, button {
-  font-size: 16px; /* ✅ évite le zoom automatique iOS */
-}
-
-canvas {
-  max-width: 100%;
-  height: auto;
-}
-
-/* améliore la transition formulaire > résultats */
-#results {
-  transition: all 0.4s ease;
-}
-
-
-/* === RESPONSIVE — STABILISATION MOBILE Lumigency === */
-@media (max-width: 900px) {
-  /* --- Layout global --- */
-  .split-layout {
-    flex-direction: column !important;
-    align-items: stretch !important;
+  from {
+    opacity: 0;
+    transform: translateY(12px);
   }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
 
-  .left-column,
-  .right-column,
-  #results {
-    width: 100% !important;
-    max-width: 100% !important;
-    padding: 24px 18px !important;
-    min-height: auto !important;
+@media (max-width: 1024px) {
+  .split-layout {
+    flex-direction: column;
+    align-items: center;
   }
 
   .left-column {
-    text-align: center;
-    background: linear-gradient(to bottom, #2020ff, #809fff);
-    border-radius: 0 0 24px 24px;
-    padding-bottom: 40px !important;
+    width: 100%;
+    padding: 50px 36px 40px;
   }
 
-  .left-column img {
-    max-width: 120px;
-    margin-bottom: 10px;
+  .right-column {
+    width: 100%;
+    padding: 40px 36px;
   }
 
-  .left-column h1 {
-    font-size: 1.3rem;
-    line-height: 1.4;
-    margin-bottom: 14px;
+  .results-section {
+    max-width: 720px;
+    padding: 32px;
   }
 
-  /* --- Avantages --- */
-  .benefits-list {
-    margin: 20px auto 0 auto;
-    padding: 0;
-    text-align: left;
-    align-items: flex-start;
-    gap: 8px;
+  .kpi-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .benefits-list li {
-    font-size: 0.9rem;
-    gap: 8px;
-    line-height: 1.4;
+  .editor-grid {
+    grid-template-columns: repeat(3, minmax(140px, 1fr));
   }
 
-  /* --- Carte “Le saviez-vous” --- */
+  .review {
+    flex: 0 0 50%;
+  }
+}
+
+@media (max-width: 768px) {
+  .left-column {
+    padding: 40px 24px 32px;
+    gap: 20px;
+  }
+
+  .left-column .logo-wrap {
+    max-width: 100px;
+  }
+
   .insight-card {
-    margin-top: 18px;
     max-width: 100%;
-    padding: 18px;
-    font-size: 0.9rem;
   }
 
   .lumigency-signature {
-    position: relative;
-    bottom: auto;
-    left: auto;
-    transform: none;
-    margin-top: 25px;
-    white-space: normal;
-    font-size: 0.8rem;
+    padding-bottom: 10px;
   }
 
-  /* --- Formulaire --- */
+  .right-column {
+    padding: 26px 22px;
+    max-width: 100%;
+  }
+
   form {
     padding: 22px;
-    border-radius: 10px;
     box-shadow: none;
+    gap: 18px;
   }
 
-  .form-row {
-    grid-template-columns: 1fr !important;
-    gap: 18px;
+  .results-section,
+  .kpi-card,
+  .editor-card,
+  .review {
+    box-shadow: none;
   }
 
   .traffic-slider-container {
     flex-direction: column;
     align-items: stretch;
-    gap: 10px;
-  }
-
-  .slider-wrapper {
-    max-width: 100%;
-  }
-
-  .slider-labels {
-    font-size: 0.75rem;
-    padding: 0;
   }
 
   .traffic-slider-container input[type="number"] {
-    width: 100%;
+    max-width: 100%;
     text-align: left;
-    margin-top: 4px;
+  }
+
+  .form-row {
+    grid-template-columns: 1fr;
   }
 
   .checkbox-group {
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
+    grid-template-columns: 1fr;
   }
 
-  .single-checkbox,
-  .checkbox-budget,
   .radio-group {
-    align-items: flex-start;
     flex-direction: column;
-    gap: 6px;
-    font-size: 0.9rem;
-    line-height: 1.3;
+    align-items: flex-start;
+    gap: 12px;
   }
 
   .cta {
-    width: 100%;
     font-size: 1rem;
-    padding: 14px;
-    margin-top: 20px;
   }
 
-  .cta-secondary {
-    margin-top: 10px;
-    font-size: 0.9rem;
+  .cta:hover {
+    transform: none;
   }
 
-  /* --- Résultats --- */
   .results-section {
-    padding: 25px 18px;
+    padding: 28px 22px;
+    align-items: center;
+  }
+
+  .results-section .subtitle {
+    text-align: center;
   }
 
   .kpi-grid {
     grid-template-columns: 1fr;
-    gap: 16px;
   }
 
-  .kpi-card {
+  .analysis-block {
     padding: 18px;
   }
 
-  .chart-container,
-  .analysis-block,
   .editor-grid {
-    max-width: 100%;
-    padding: 0;
+    grid-template-columns: repeat(2, minmax(140px, 1fr));
   }
 
-  /* --- Slider Témoignages --- */
   .review {
     flex: 0 0 100%;
-    margin: 0 5px;
-  }
-
-  .testimonials-section h2 {
-    font-size: 1.4rem;
-    margin-bottom: 18px;
-  }
-
-  .review p {
-    font-size: 0.9rem;
-  }
-}
-/* === 🌙 OPTIMISATION MOBILE DU SIMULATEUR LUMIGENCY === */
-@media (max-width: 768px) {
-
-  /* === GLOBAL === */
-  body {
-    background-color: #f8f9ff;
-    overflow-x: hidden;
-  }
-
-  .split-layout {
-    display: flex;
-    flex-direction: column;
-    padding: 20px 16px;
-  }
-
-  .left-column, .right-column {
-    width: 100%;
-  }
-
-  h1, h2, h3 {
-    text-align: center;
-    line-height: 1.3;
-  }
-
-  .cta, .cta-secondary {
-    width: 100%;
-    display: block;
-    text-align: center;
-    margin: 18px auto;
-  }
-
-  /* === ALIGNEMENT INPUTS === */
-  input[type="number"], input[type="url"], input[type="email"], select {
-    width: 100%;
-    padding: 12px;
-    font-size: 0.95rem;
-    border: 1px solid #ddd;
-    border-radius: 8px;
-    box-sizing: border-box;
-  }
-
-  /* Range bien centré */
-  .traffic-slider-container {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    margin-bottom: 20px;
-  }
-
-  .slider-wrapper {
-    width: 100%;
-    text-align: center;
-  }
-
-  .slider-labels {
-    display: flex;
-    justify-content: space-between;
-    font-size: 0.8rem;
-    width: 100%;
-    margin-top: 4px;
-  }
-
-  /* === CHECKBOXES & RADIOS === */
-  .checkbox-budget,
-  .single-checkbox {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    flex-wrap: nowrap;
-    margin: 10px 0;
-    font-size: 0.9rem;
-    line-height: 1.4;
-  }
-
-  .checkbox-budget input[type="checkbox"],
-  .single-checkbox input[type="checkbox"] {
-    flex-shrink: 0;
-    transform: scale(1.2);
-    accent-color: #0000FF;
-  }
-
-  .radio-group {
-    display: flex;
-    align-items: center;
-    gap: 16px;
-    margin-bottom: 15px;
-  }
-
-  /* === SECTION RÉSULTATS === */
-  .results-section {
-    background-color: #f8f9ff;
-    padding: 30px 16px;
-  }
-
-  .results-section h2 {
-    font-size: 1.25rem;
-    color: #0000FF;
-    margin-bottom: 10px;
-  }
-
-  .results-section .subtitle {
-    font-size: 0.95rem;
-    text-align: center;
-    margin-bottom: 25px;
-    line-height: 1.4;
-  }
-
-  /* === KPI GRID === */
-  .kpi-grid {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: 10px;
-    margin-bottom: 25px;
-  }
-
-  .kpi-card {
-    background: #fff;
-    border-radius: 10px;
-    padding: 10px;
-    text-align: center;
-    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
-    font-size: 0.9rem;
-  }
-
-  .kpi-card strong {
-    display: block;
-    font-size: 0.8rem;
-    color: #333;
-    margin-bottom: 4px;
-  }
-
-  .kpi-card span {
-    color: #0000FF;
-    font-weight: 600;
-    font-size: 0.95rem;
-  }
-
-  /* === GRAPHIQUE === */
-  .chart-container {
-    width: 100%;
-    max-width: 320px;
-    margin: 0 auto 25px auto;
-  }
-
-  /* === ANALYSE === */
-  .analysis-block {
-    background: #fff;
-    border-radius: 10px;
-    padding: 15px;
-    margin-bottom: 25px;
-    box-shadow: 0 2px 6px rgba(0,0,0,0.05);
-  }
-
-  .analysis-block h3 {
-    font-size: 1rem;
-    color: #0000FF;
-    margin-bottom: 10px;
-    text-align: center;
-  }
-
-  .analysis-block ul {
-    padding-left: 18px;
-  }
-
-  /* === SUGGESTIONS ÉDITEURS === */
-  .editor-grid {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: 12px;
-    margin-bottom: 20px;
-  }
-
-  .editor-grid .editor-card {
-    background: #fff;
-    border-radius: 12px;
-    text-align: center;
-    padding: 10px;
-    box-shadow: 0 2px 5px rgba(0,0,0,0.05);
-    font-size: 0.85rem;
-  }
-
-  /* === OPT-IN & CTA === */
-  .editor-optin {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    justify-content: center;
-    font-size: 0.9rem;
-    margin-bottom: 20px;
-  }
-
-  #cta-link .cta {
-    display: block;
-    text-align: center;
-    background-color: #849BFF;
-    border-radius: 10px;
-    color: white;
-    padding: 14px;
-    font-weight: 600;
-    margin: 0 auto 15px auto;
-  }
-
-  #restart-btn {
-    text-align: center;
-    margin-top: 8px;
-    font-size: 0.9rem;
-    color: #0000FF;
-  }
-
-  /* === MARGES FINALES === */
-  .results-section,
-  .editor-grid,
-  .analysis-block,
-  .kpi-grid {
-    scroll-margin-top: 70px;
-  }
-
-  .results-section h3,
-  .editor-suggestions h3 {
-    color: #0000FF;
-  }
-}
-
-/* === BONUS PREMIUM === */
-@media (prefers-reduced-motion: no-preference) {
-  .kpi-card, .editor-card {
-    opacity: 0;
-    transform: translateY(15px);
-    animation: fadeUp 0.6s ease forwards;
-  }
-
-  @keyframes fadeUp {
-    to {
-      opacity: 1;
-      transform: translateY(0);
-    }
-  }
-}
-/* === Correctifs version mobile (affichage et alignements) === */
-@media (max-width: 768px) {
-
-  /* ✅ Correction slider "trafic mensuel" */
-  .traffic-slider-container {
-    align-items: center;
-  }
-
-  .traffic-slider-container input[type="number"] {
-    width: 120px;
-    text-align: center;
-  }
-
-  /* ✅ Case + texte sur la même ligne */
-  .checkbox-budget,
-  .single-checkbox {
-    flex-direction: row !important;
-    align-items: center !important;
-    justify-content: flex-start;
-  }
-
-  .checkbox-budget label,
-  .single-checkbox label {
-    margin: 0;
-    line-height: 1.2;
-    font-size: 0.9rem;
-    white-space: normal;
-  }
-
-  .checkbox-budget input[type="checkbox"],
-  .single-checkbox input[type="checkbox"] {
-    flex-shrink: 0;
-    transform: scale(1.2);
-    margin-right: 8px;
-  }
-
-  /* ✅ Résultats stabilisés et centrés */
-  .results-section {
-    width: 100%;
-    max-width: 100%;
-    margin: 0 auto;
-    text-align: center;
-  }
-
-  .results-section h2,
-  .results-section .subtitle {
-    text-align: center;
-  }
-
-  /* ✅ Bloc analyse pas coupé */
-  .analysis-block {
-    max-width: 100%;
-    overflow-x: hidden;
-    text-align: left;
-    word-break: break-word;
-    margin: 0 auto 20px;
-  }
-
-  /* ✅ Éditeurs : 2 par ligne sur mobile */
-  .editor-grid {
-    display: grid !important;
-    grid-template-columns: repeat(2, 1fr) !important;
-    gap: 12px !important;
-    justify-content: center !important;
-    max-width: 100%;
-    padding: 0 10px;
-  }
-
-  .editor-card {
-    width: 100%;
-    height: auto;
-    min-height: 110px;
-  }
-
-  .editor-card img {
-    max-width: 70px;
-    margin-bottom: 6px;
-  }
-
-  .editor-card span {
-    font-size: 0.85rem;
-  }
-}
-
-/* === CORRECTIF ALIGNEMENT GLOBAL MOBILE (v1.1) === */
-@media (max-width: 768px) {
-
-  /* ✅ Forcer le centrage horizontal de tout le contenu */
-  body, html {
-    overflow-x: hidden !important;
-    text-align: center !important;
-    margin: 0 auto !important;
-    padding: 0 !important;
-  }
-
-  .split-layout,
-  .right-column,
-  #results,
-  form,
-  .results-section,
-  .chart-container,
-  .analysis-block,
-  .editor-grid,
-  .cta-final,
-  .testimonials-section {
-    width: 100% !important;
-    max-width: 100% !important;
-    margin: 0 auto !important;
-    text-align: center !important;
-    justify-content: center !important;
-    align-items: center !important;
-  }
-
-  /* ✅ Titre principal et sous-titres */
-  h1, h2, h3, .subtitle {
-    text-align: center !important;
-    margin-left: auto !important;
-    margin-right: auto !important;
-  }
-
-  /* ✅ Bloc analyse lisible et centré */
-  .analysis-block {
-    text-align: left !important;
-    width: 90% !important;
-    margin: 0 auto 25px auto !important;
-    padding: 16px !important;
-    word-break: break-word !important;
-  }
-
-  /* ✅ Éditeurs : centrés, pas de chevauchement */
-  .editor-grid {
-    display: grid !important;
-    grid-template-columns: repeat(2, 1fr) !important;
-    gap: 16px !important;
-    justify-items: center !important;
-    align-items: stretch !important;
-    width: 90% !important;
-    margin: 0 auto 25px auto !important;
-  }
-
-  .editor-card {
-    width: 100% !important;
-    max-width: 160px !important;
-    height: auto !important;
-    min-height: 120px !important;
-    display: flex !important;
-    flex-direction: column !important;
-    justify-content: center !important;
-    align-items: center !important;
-  }
-
-  .editor-card img {
-    max-width: 80px !important;
-    margin-bottom: 8px !important;
-  }
-
-  /* ✅ CTA bien centré */
-  .cta, .cta-secondary, #cta-link, #restart-btn {
-    text-align: center !important;
-    margin-left: auto !important;
-    margin-right: auto !important;
-    display: block !important;
-  }
-
-  /* ✅ Corrige légères marges parasites sur iPhone */
-  * {
-    box-sizing: border-box;
-  }
-}
-/* === PATCH CORRECTIF FINAL MOBILE LUMIGENCY (v2.0) === */
-@media (max-width: 768px) {
-
-  /* ✅ Correction centrage global */
-  .right-column,
-  #results,
-  form,
-  .results-section {
-    width: 100% !important;
-    margin: 0 auto !important;
-    text-align: center !important;
-    padding-left: 0 !important;
-    padding-right: 0 !important;
-  }
-
-  /* ✅ Titre “Renseignez vos données clés” centré */
-  h2, h3, .section-title, .intro-text {
-    text-align: center !important;
-    margin-left: auto !important;
-    margin-right: auto !important;
-  }
-
-  /* ✅ “Oui / Non” sur la même ligne */
-  .radio-group {
-    display: flex !important;
-    flex-direction: row !important;
-    justify-content: center !important;
-    align-items: center !important;
-    gap: 30px !important;
-    margin-top: 8px !important;
-  }
-
-  .radio-group label {
-    display: flex !important;
-    align-items: center !important;
-    gap: 6px !important;
-    font-size: 0.95rem !important;
-  }
-
-  /* ✅ Réduction espace entre opt-in et CTA */
-  .editor-optin {
-    margin-bottom: 12px !important;
-  }
-
-  #cta-link {
-    margin-top: 0 !important;
-  }
-
-  /* ✅ Ajustement fin du centrage visuel global */
-  .traffic-slider-container,
-  .checkbox-budget,
-  .single-checkbox,
-  .editor-grid {
-    margin-left: auto !important;
-    margin-right: auto !important;
-  }
-}
-/* === Responsive colonne & formulaires optimisé pour mobile (max 768px) === */
-@media (max-width: 768px) {
-  .split-layout {
-    flex-direction: column !important;
-    align-items: center !important;
-    gap: 24px !important;
-    padding: 20px 0 !important;
-  }
-
-  .left-column,
-  .right-column,
-  .split-layout.show-results #results {
-    width: 95% !important;
-    max-width: 390px !important;
-    padding: 24px 18px !important;
-    box-sizing: border-box;
-  }
-
-  .left-column {
-    text-align: left !important;
-    align-items: flex-start !important;
-    margin-bottom: 12px !important;
-  }
-
-  .left-column h1 {
-    font-size: 1.35rem !important;
-    line-height: 1.35 !important;
-  }
-
-  .left-column .benefits-list {
-    align-items: flex-start !important;
-    width: 100% !important;
-    max-width: 100% !important;
-  }
-
-  body,
-  html {
-    text-align: left !important;
-  }
-
-  form {
-    padding: 24px 18px !important;
-    box-shadow: none !important;
-  }
-
-  label,
-  input,
-  select,
-  button {
-    font-size: 0.9rem !important;
-  }
-
-  .checkbox-group {
-    display: grid !important;
-    grid-template-columns: 1fr !important;
-    gap: 12px !important;
-    width: 100% !important;
-  }
-
-  .checkbox-group label,
-  .single-checkbox,
-  .checkbox-budget,
-  .radio-group {
-    width: 100% !important;
-    justify-content: flex-start !important;
-    align-items: flex-start !important;
-    text-align: left !important;
-  }
-
-  .radio-group {
-    flex-direction: column !important;
-    gap: 12px !important;
-  }
-
-  .radio-group label {
-    justify-content: flex-start !important;
-    font-size: 0.9rem !important;
-  }
-
-  .traffic-slider-container {
-    flex-direction: column !important;
-    align-items: stretch !important;
-    gap: 12px !important;
-  }
-
-  .traffic-slider-container input[type="number"] {
-    width: 100% !important;
-  }
-
-  .cta {
-    font-size: 1rem !important;
-    width: 100% !important;
-    padding: 14px !important;
-  }
-
-  .cta-secondary {
-    font-size: 0.9rem !important;
+    margin: 0 6px;
   }
 }


### PR DESCRIPTION
## Summary
- streamline the CSS with a single desktop base and focused tablet/mobile breakpoints
- rework the left branding column to center the logo, align benefits, and preserve Lumigency styling on all viewports
- stabilize the results, editor grid, and testimonials layouts so KPIs, charts, and cards keep consistent spacing across devices

## Testing
- Manual – Loaded index.html locally via `python3 -m http.server 8000` and verified desktop, tablet, and mobile layouts

------
https://chatgpt.com/codex/tasks/task_e_68eed0778f0083238c7148f70221cfb2