### PR TITLE
Restore desktop layout and refine responsive breakpoints

### DIFF
--- a/style.css
+++ b/style.css
@@ -10,7 +10,7 @@ body {
 body {
   margin: 0;
   font-family: 'Poppins', sans-serif;
-  font-size: 0.95rem;
+  font-size: 1rem;
   line-height: 1.5;
   background: #F7F5F3;
   color: #222;
@@ -41,14 +41,17 @@ button {
 
 .left-column {
   width: 35%;
-  background: linear-gradient(to bottom, #2020ff, #809fff);
+  background: linear-gradient(to bottom, #0000FF, #849BFF);
   color: #ffffff;
   padding: 60px 40px 40px;
   display: flex;
   flex-direction: column;
   align-items: center;
   text-align: center;
-  position: relative;
+  position: sticky;
+  top: 0;
+  min-height: 100vh;
+  align-self: stretch;
   gap: 24px;
 }
 
@@ -70,6 +73,8 @@ button {
   font-size: 1.7rem;
   margin: 0;
   color: #ffffff;
+  font-weight: 600;
+  line-height: 1.3;
 }
 
 .benefits-list {
@@ -125,7 +130,7 @@ button {
   width: 60%;
   max-width: 700px;
   padding: 50px;
-  background: #ffffff;
+  background: #F7F5F3;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -135,6 +140,7 @@ button {
   font-size: 1.4rem;
   margin: 0 0 25px;
   color: #0000FF;
+  font-weight: 600;
 }
 
 .right-column .subtitle mark {
@@ -546,6 +552,12 @@ textarea {
   color: #777777;
 }
 
+.stars {
+  color: #27AE60;
+  font-weight: 600;
+  letter-spacing: 2px;
+}
+
 @keyframes fadeIn {
   from {
     opacity: 0;
@@ -566,6 +578,10 @@ textarea {
   .left-column {
     width: 100%;
     padding: 50px 36px 40px;
+    position: static;
+    top: auto;
+    min-height: auto;
+    align-self: stretch;
   }
 
   .right-column {
@@ -573,7 +589,8 @@ textarea {
     max-width: 420px;
     padding: 28px 24px;
     margin: 0 auto;
-    align-items: center;
+    align-items: stretch;
+    background: #F7F5F3;
   }
 
   .results-section {
@@ -620,19 +637,21 @@ textarea {
   }
 
   .checkbox-group {
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 12px 16px;
     width: 100%;
   }
 
   .checkbox-group label {
     justify-content: flex-start;
+    width: 100%;
   }
 
   .single-checkbox {
     justify-content: center;
     text-align: center;
+    width: 100%;
   }
 
   .single-checkbox input,
@@ -649,9 +668,10 @@ textarea {
     justify-content: center;
     align-items: center;
     gap: 8px;
-    white-space: nowrap;
-    font-size: clamp(0.35rem, 1.4vw, 0.95rem);
+    white-space: normal;
+    font-size: 0.95rem;
     text-align: center;
+    line-height: 1.4;
     padding: 0 12px;
     max-width: 100%;
   }
@@ -666,13 +686,24 @@ textarea {
 }
 
 @media (max-width: 768px) {
+  body {
+    font-size: 0.95rem;
+  }
+
   .left-column {
-    padding: 40px 24px 32px;
+    padding: 24px 20px;
     gap: 20px;
+    position: static;
+    top: auto;
+    min-height: auto;
   }
 
   .left-column .logo-wrap {
     max-width: 100px;
+  }
+
+  .left-column h1 {
+    font-size: 1.3rem;
   }
 
   .insight-card {
@@ -685,6 +716,11 @@ textarea {
 
   .right-column {
     padding: 24px 20px;
+    background: #F7F5F3;
+  }
+
+  .right-column .subtitle {
+    font-size: 1.3rem;
   }
 
   form {
@@ -698,6 +734,58 @@ textarea {
   .editor-card,
   .review {
     box-shadow: none;
+  }
+
+  .levers-section {
+    gap: 16px;
+    align-items: stretch;
+  }
+
+  .levers-section .section-title {
+    text-align: center;
+    margin-bottom: 8px;
+  }
+
+  .single-checkbox {
+    justify-content: flex-start;
+    width: 100%;
+  }
+
+  .checkbox-group {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    width: 100%;
+  }
+
+  .checkbox-group label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .single-checkbox,
+  .checkbox-group label {
+    text-align: left;
+  }
+
+  .editor-optin {
+    justify-content: center;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+
+  .editor-optin-label {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.95rem;
+    text-align: center;
+    line-height: 1.4;
   }
 
   .traffic-slider-container {
@@ -724,7 +812,7 @@ textarea {
     font-size: 1rem;
     width: 100%;
     max-width: 360px;
-    margin: 0 auto;
+    margin: 0 auto 40px;
   }
 
   .cta:hover {
@@ -766,12 +854,16 @@ textarea {
 
   .review {
     flex: 0 0 100%;
-    margin: 0 6px;
+    margin: 0;
   }
 
   .cta-secondary {
     margin-bottom: 40px;
     display: flex;
     justify-content: center;
+  }
+
+  .testimonials-section {
+    padding: 24px 20px;
   }
 }


### PR DESCRIPTION
## Summary
- restore the desktop split layout with the original blue gradient panel and beige form area while reinstating heading typography and testimonial star color
- adjust tablet and mobile levers, opt-in, KPI grid, CTA, and testimonials layouts to remove overflow and ensure the requested stacking and spacing
- tune mobile typography and section padding to match the desired scale while keeping backgrounds consistent

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68eed788a1a48323bb581f92c0909d4a