### PR TITLE
Adjust benefits list alignment

### DIFF
--- a/style.css
+++ b/style.css
@@ -31,83 +31,80 @@ body {
 /* Titre principal */
 .left-column h1 {
   font-size: 1.7rem;
-  margin-bottom: 30px;
+  margin: 0 auto 30px;
   line-height: 1.3;
-}
-
-/* Bénefits */
-.benefits-list li::first-letter {
-  line-height: 1;
-}
-.benefits-list li {
-
-  font-size: 0.95rem;
-  margin: 10px 0;
-  line-height: 1.6;
-  color: #f7f7f7;
-  display: flex;
-  align-items: center;          /* ✅ centre parfaitement verticalement emoji + texte */
-  justify-content: center;      /* ✅ centre horizontalement dans la colonne */
-  gap: 10px;                    /* espace fixe entre emoji et texte */
-  text-align: center;
-  white-space: nowrap;          /* ✅ empêche le retour à la ligne */
-}
-
-.left-column .benefits-list li .check-icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  line-height: 1;
-}
-
-.benefits-list li span {
-  display: inline-block;
-  line-height: 1;               /* ✅ garde le texte centré verticalement */
-  vertical-align: middle;
-  font-size: 0.95rem;
-}
-
-/* Pour mobile */
-/* === ✅ ALIGNEMENT PARFAIT DES ✔ DANS LA LISTE LUMIGENCY === */
-.benefits-list {
-  list-style: none;
-  padding: 0;
-  margin: 0 auto;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
   max-width: 360px;
   width: 100%;
 }
 
-.benefits-list li {
+/* Bénefits */
+.benefits-list {
+  list-style: none;
+  padding: 0;
+  margin: 0 auto 32px;
   display: flex;
-  align-items: center;   /* aligne ✔ + texte verticalement */
-  gap: 10px;             /* espace entre ✔ et texte */
-  text-align: left;
-  color: #fff;
+  flex-direction: column;
+  gap: 12px;
+  width: 100%;
+  max-width: 360px;
+}
+
+.benefits-list li {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 8px;
   font-size: 0.95rem;
   line-height: 1.5;
+  color: #f7f7f7;
+  text-align: left;
+  white-space: nowrap;
 }
 
 .benefits-list .check-icon {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 20px;           /* largeur fixe pour alignement stable */
-  height: 20px;
+  width: 22px;
+  height: 22px;
   flex-shrink: 0;
   font-size: 1rem;
   line-height: 1;
-  transform: translateY(1px); /* ajuste la hauteur visuelle */
+  margin-right: 0;
 }
 
-.benefits-list li::before {
-  content: none !important;
+.benefits-list li span {
+  flex: 1;
+  display: inline-flex;
+  align-items: center;
+  line-height: 1.5;
+  white-space: normal;
 }
 
-/* ✅ Supprime les icônes "✅" ou puces */
+@media (min-width: 769px) {
+  .left-column {
+    align-items: center;
+  }
+
+  .benefits-list {
+    align-items: center;
+  }
+
+  .benefits-list li {
+    justify-content: center;
+    width: auto;
+    max-width: none;
+    margin: 0 auto;
+  }
+
+  .benefits-list li span {
+    justify-content: flex-start;
+    text-align: left;
+  }
+}
+
+/* ✅ Supprime les puces natives */
+.benefits-list li::before,
 .left-column ul li::before {
   content: none;
 }
@@ -574,37 +571,10 @@ select {
     text-align: center;
   }
 
-  .left-column .benefits-list,
-  .left-column .benefits-list li,
   .left-column .insight-card,
   .left-column .lumigency-signature {
     text-align: center;
     margin: 0 auto;
-  }
-
-  .left-column .benefits-list {
-    width: 100%;
-    max-width: 360px;
-    padding: 0;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 16px;
-  }
-
-  .left-column .benefits-list li {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 8px;
-    line-height: 1.35;
-    text-align: center;
-    white-space: normal;
-  }
-
-  .left-column .benefits-list li span {
-    text-align: center;
-    line-height: 1.35;
   }
 
   .left-column .insight-card {
@@ -889,35 +859,6 @@ html, body {
   height: 100%;
 }
 
-/* === Ajustement final : alignement, bloc blanc, ligne signature === */
-.benefits-list {
-  list-style: none;
-  padding: 0;
-  margin: 0 auto 40px auto;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  width: 100%;
-  max-width: 380px;
-}
-
-.benefits-list li {
-  display: grid;
-  grid-template-columns: 28px auto;
-  align-items: center;
-  justify-content: center;
-  gap: 10px;
-  font-size: 0.95rem;
-  line-height: 1.6;
-  color: #f7f7f7;
-  margin: 8px 0;
-  text-align: left;
-}
-
-.benefits-list li span {
-  display: block;
-}
-
 .insight-card {
   background: #ffffff;
   color: #1a1a1a;
@@ -1026,46 +967,6 @@ html, body {
   .review {
     flex: 0 0 100%; /* 1 témoignage à la fois sur mobile */
   }
-}
-
-/* ✅ Liste des arguments — alignement parfait emoji + texte */
-.benefits-list {
-  list-style: none;
-  padding: 0;
-  margin: 0 auto 25px auto;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start; /* aligne tout à gauche, plus naturel */
-  gap: 16px;
-  width: 100%;
-  max-width: 360px;
-}
-
-.benefits-list li {
-  display: flex;
-  align-items: center;        /* ✅ centre emoji + texte verticalement */
-  justify-content: flex-start;
-  gap: 10px;
-  font-size: 0.95rem;
-  color: #fff;
-  line-height: 1.6;
-  text-align: left;
-}
-
-.benefits-list li::before {
-  content: attr(data-emoji);
-  font-size: 1.2rem;          /* ✅ taille uniforme */
-  line-height: 1;             /* ✅ corrige le décalage vertical */
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 22px;            /* ✅ espace constant */
-}
-
-.benefits-list li span {
-  display: inline-block;
-  vertical-align: middle;
-  line-height: 1.4;
 }
 
 
@@ -1217,21 +1118,6 @@ canvas {
     font-size: 1.3rem;
     line-height: 1.4;
     margin-bottom: 14px;
-  }
-
-  /* --- Avantages --- */
-  .benefits-list {
-    margin: 20px auto 0 auto;
-    padding: 0;
-    text-align: left;
-    align-items: flex-start;
-    gap: 8px;
-  }
-
-  .benefits-list li {
-    font-size: 0.9rem;
-    gap: 8px;
-    line-height: 1.4;
   }
 
   /* --- Carte “Le saviez-vous” --- */


### PR DESCRIPTION
## Summary
- left-align the inline-flex benefits list items so the check icon and text stay on a single row with consistent spacing
- keep the check icon layout intact while centering the overall block as before

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f0297904108323ab2822b019814b92