### PR TITLE
Adjust mobile radio group layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -1663,24 +1663,20 @@ canvas {
     align-items: center !important;
     gap: 24px !important;
     flex-wrap: nowrap !important;
-    margin-top: 6px !important;
-    width: 100% !important;
   }
 
   .radio-group label {
     display: inline-flex !important;
     align-items: center !important;
+    justify-content: center !important;
     gap: 6px !important;
     font-size: 0.95rem !important;
-    line-height: 1.2 !important;
-    white-space: nowrap !important; /* empêche le retour à la ligne */
-    justify-content: center !important;
-    text-align: center !important;
+    white-space: nowrap !important;
   }
 
   .radio-group input[type="radio"] {
-    flex-shrink: 0 !important;
     transform: scale(1.1) !important;
-    margin: 0 4px 0 0 !important; /* espace doux à gauche */
+    flex-shrink: 0 !important;
+    margin-right: 4px !important;
   }
 }


### PR DESCRIPTION
## Summary
- update the mobile media query for `.radio-group` to keep radio options on a single centered row
- ensure radio labels remain inline-flex with centered alignment while scaling the inputs slightly for usability

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f177c1bf748323b3efb872da0cf16a