### PR TITLE
fix: final mobile alignment for Oui/Non radio buttons (Safari/iOS)

### DIFF
--- a/style.css
+++ b/style.css
@@ -1663,24 +1663,52 @@ canvas {
     align-items: center !important;
     gap: 24px !important;
     flex-wrap: nowrap !important;
-    margin-top: 6px !important;
-    width: 100% !important;
   }
 
   .radio-group label {
     display: inline-flex !important;
     align-items: center !important;
+    justify-content: center !important;
     gap: 6px !important;
     font-size: 0.95rem !important;
-    line-height: 1.2 !important;
-    white-space: nowrap !important; /* empêche le retour à la ligne */
+    white-space: nowrap !important;
+  }
+
+  .radio-group input[type="radio"] {
+    transform: scale(1.1) !important;
+    flex-shrink: 0 !important;
+    margin-right: 4px !important;
+  }
+}
+/* ✅ Fix définitif iOS Safari - radio Oui/Non sur une seule ligne */
+@media (max-width: 768px) {
+  .radio-group {
+    display: flex !important;
+    flex-direction: row !important;
     justify-content: center !important;
-    text-align: center !important;
+    align-items: center !important;
+    gap: 18px !important;
+    flex-wrap: nowrap !important;
+    line-height: 1 !important;
+  }
+
+  .radio-group label {
+    display: flex !important;
+    flex-direction: row !important;
+    align-items: center !important;
+    justify-content: center !important;
+    gap: 8px !important;
+    font-size: 1rem !important;
+    white-space: nowrap !important;
+    line-height: 1 !important;
   }
 
   .radio-group input[type="radio"] {
     flex-shrink: 0 !important;
+    margin: 0 !important;
     transform: scale(1.1) !important;
-    margin: 0 4px 0 0 !important; /* espace doux à gauche */
+    vertical-align: middle !important;
+    position: relative !important;
+    top: 0 !important;
   }
 }


### PR DESCRIPTION
## Summary
- append the definitive iOS Safari mobile styles to keep the Oui/Non radio inputs and labels perfectly aligned on one line

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f177c1bf748323b3efb872da0cf16a