### PR TITLE
fix: align radio Oui/Non labels consistently on all devices (Safari & Chrome mobile)

### DIFF
--- a/style.css
+++ b/style.css
@@ -1716,3 +1716,33 @@ canvas {
   }
 }
 
+/* === Correctif alignement radio Oui / Non (Safari iOS & Chrome Android) === */
+.radio-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 18px;
+  flex-wrap: wrap;
+}
+
+.radio-item {
+  display: inline-flex !important;
+  align-items: center;
+  gap: 8px;
+  line-height: 1.2;
+}
+
+.radio-item input[type="radio"] {
+  flex: 0 0 auto;
+  width: auto;
+  height: auto;
+  margin: 0;
+  appearance: auto !important;
+  -webkit-appearance: radio !important;
+  transform: none !important;
+  position: static !important;
+}
+
+.radio-item span {
+  display: inline-block;
+  line-height: 1.2;
+}


### PR DESCRIPTION
## Summary
- prevent transformed radio inputs from stretching their labels on mobile Safari by resetting their dimensions and layout
- use inline-flex alignment for the Oui/Non radio container so bubbles and text stay perfectly centered together on every viewport

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f17c21f35483239d25dad080ddd4f4